### PR TITLE
Increase and set the resource limit for tb-web-report service

### DIFF
--- a/aws/microservices/tb-services.yml
+++ b/aws/microservices/tb-services.yml
@@ -419,8 +419,8 @@ spec:
           image: thingsboard/tb-pe-web-report:3.4.0PE
           resources:
             limits:
-              cpu: "100m"
-              memory: 500Mi
+              cpu: "800m"
+              memory: 1000Mi
           ports:
             - containerPort: 8383
               name: http

--- a/azure/microservices/tb-services.yml
+++ b/azure/microservices/tb-services.yml
@@ -313,6 +313,10 @@ spec:
         - name: server
           imagePullPolicy: Always
           image: thingsboard/tb-pe-web-report:3.4.0PE
+          resources:
+            limits:
+              cpu: "800m"
+              memory: 1000Mi
           ports:
             - containerPort: 8383
               name: http

--- a/gcp/microservices/tb-services.yml
+++ b/gcp/microservices/tb-services.yml
@@ -334,6 +334,10 @@ spec:
         - name: server
           imagePullPolicy: Always
           image: thingsboard/tb-pe-web-report:3.4.0PE
+          resources:
+            limits:
+              cpu: "800m"
+              memory: 1000Mi
           ports:
             - containerPort: 8383
               name: http


### PR DESCRIPTION
Increase resource limit for tb-web-report service because 100m CPU limit was not enough for report generation. When generating a dashboard report with multiple widgets, tb-web-report uses 600m on average.
Setting limits for tb-web-report to deploy GCP, and Azure due to their absence.