### PR TITLE
fix "tb-js-executor" image name typo

### DIFF
--- a/aws/microservices/tb-services.yml
+++ b/aws/microservices/tb-services.yml
@@ -378,7 +378,7 @@ spec:
       containers:
         - name: server
           imagePullPolicy: Always
-          image: thingsboard/tb-js-executor:3.4.4PE
+          image: thingsboard/tb-pe-js-executor:3.4.4PE
           resources:
             limits:
               cpu: "100m"


### PR DESCRIPTION
This repo is for PE and the `thingsboard/tb-js-executor:3.4.4PE` doesn't exist. But if we add `-pe` to the image name, like all the other images in this yaml file, to get `thingsboard/tb-pe-js-executor:3.4.4PE`, that works great. [Link to DockerHub for PE image](https://hub.docker.com/layers/thingsboard/tb-pe-js-executor/3.4.4PE/images/sha256-b2b1509d58c5d17662b0ead480d9c7d8ad837a38ad9a86bef76fc5e43cf68db0?context=explore).