### PR TITLE
Enable dashboard reload for each report

### DIFF
--- a/aws/microservices/tb-services.yml
+++ b/aws/microservices/tb-services.yml
@@ -451,6 +451,8 @@ spec:
               value: "120000"
             - name: DASHBOARD_LOAD_WAIT_TIME
               value: "3000"
+            - name: "USE_NEW_PAGE_FOR_REPORT"
+              value: "true"
           readinessProbe:
             periodSeconds: 20
             tcpSocket:

--- a/aws/monolith/tb-node.yml
+++ b/aws/monolith/tb-node.yml
@@ -226,6 +226,8 @@ spec:
               value: "120000"
             - name: DASHBOARD_LOAD_WAIT_TIME
               value: "3000"
+            - name: "USE_NEW_PAGE_FOR_REPORT"
+              value: "true"
           readinessProbe:
             periodSeconds: 20
             tcpSocket:

--- a/azure/microservices/tb-services.yml
+++ b/azure/microservices/tb-services.yml
@@ -336,6 +336,8 @@ spec:
               value: "120000"
             - name: DASHBOARD_LOAD_WAIT_TIME
               value: "3000"
+            - name: "USE_NEW_PAGE_FOR_REPORT"
+              value: "true"
           readinessProbe:
             periodSeconds: 20
             tcpSocket:

--- a/azure/monolith/tb-node.yml
+++ b/azure/monolith/tb-node.yml
@@ -220,6 +220,8 @@ spec:
               value: "120000"
             - name: DASHBOARD_LOAD_WAIT_TIME
               value: "3000"
+            - name: "USE_NEW_PAGE_FOR_REPORT"
+              value: "true"
           readinessProbe:
             periodSeconds: 20
             tcpSocket:

--- a/gcp/microservices/tb-services.yml
+++ b/gcp/microservices/tb-services.yml
@@ -356,6 +356,8 @@ spec:
               value: "120000"
             - name: DASHBOARD_LOAD_WAIT_TIME
               value: "3000"
+            - name: "USE_NEW_PAGE_FOR_REPORT"
+              value: "true"
           readinessProbe:
             periodSeconds: 20
             tcpSocket:

--- a/gcp/monolith/tb-node.yml
+++ b/gcp/monolith/tb-node.yml
@@ -224,6 +224,8 @@ spec:
               value: "120000"
             - name: DASHBOARD_LOAD_WAIT_TIME
               value: "3000"
+            - name: "USE_NEW_PAGE_FOR_REPORT"
+              value: "true"
           readinessProbe:
             periodSeconds: 20
             tcpSocket:

--- a/minikube/thingsboard.yml
+++ b/minikube/thingsboard.yml
@@ -215,6 +215,8 @@ spec:
           value: "120000"
         - name: DASHBOARD_LOAD_WAIT_TIME
           value: "3000"
+        - name: "USE_NEW_PAGE_FOR_REPORT"
+          value: "true"
         readinessProbe:
           periodSeconds: 20
           tcpSocket:


### PR DESCRIPTION
Enabling `USE_NEW_PAGE_FOR_REPORT` option allows to reduce server resource utilization during idle time.