### PR TITLE
Set EKS version to 1.31

### DIFF
--- a/aws/microservices/cluster.yml
+++ b/aws/microservices/cluster.yml
@@ -1,4 +1,4 @@
-#version eksctl 0.164.0 or higher
+#version eksctl 0.191.0 or higher
 
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
@@ -10,7 +10,7 @@ metadata:
   name: thingsboard
   # Specify the desired aws region. Don't forget to update the 'availabilityZones' parameter to match the region.
   region: us-east-1
-  version: "1.28"
+  version: "1.31"
 
 iam:
   withOIDC: true

--- a/aws/monolith/cluster.yml
+++ b/aws/monolith/cluster.yml
@@ -1,4 +1,4 @@
-#version eksctl 0.164.0 or higher
+#version eksctl 0.191.0 or higher
 
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
@@ -10,7 +10,7 @@ metadata:
   name: thingsboard
   # Specify the desired aws region. Don't forget to update the 'availabilityZones' parameter to match the region.
   region: us-east-1
-  version: "1.28"
+  version: "1.31"
 
 iam:
   withOIDC: true


### PR DESCRIPTION
Updated EKS version from 1.28 to 1.31.
Updated comments in the manifest to clarify the compatibility of eksctl versions.