### PR TITLE
Security: enable Node.js Permission Model for JS executor

### DIFF
--- a/aws/microservices/tb-services.yml
+++ b/aws/microservices/tb-services.yml
@@ -404,7 +404,7 @@ spec:
             - name: SCRIPT_BODY_TRACE_FREQUENCY
               value: "1000"
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=200"
+              value: "--max-old-space-size=200 --permission --allow-fs-read=/usr/share/tb-js-executor/*"
           envFrom:
             - configMapRef:
                 name: tb-kafka-config

--- a/azure/microservices/tb-services.yml
+++ b/azure/microservices/tb-services.yml
@@ -483,7 +483,7 @@ spec:
             - name: SCRIPT_BODY_TRACE_FREQUENCY
               value: "1000"
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=200"
+              value: "--max-old-space-size=200 --permission --allow-fs-read=/usr/share/tb-js-executor/*"
           envFrom:
             - configMapRef:
                 name: tb-kafka-config

--- a/gcp/microservices/tb-services.yml
+++ b/gcp/microservices/tb-services.yml
@@ -507,7 +507,7 @@ spec:
             - name: SCRIPT_BODY_TRACE_FREQUENCY
               value: "1000"
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=200"
+              value: "--max-old-space-size=200 --permission --allow-fs-read=/usr/share/tb-js-executor/*"
           envFrom:
             - configMapRef:
                 name: tb-kafka-config

--- a/minikube/thingsboard.yml
+++ b/minikube/thingsboard.yml
@@ -164,7 +164,7 @@ spec:
         - name: SCRIPT_BODY_TRACE_FREQUENCY
           value: "1000"
         - name: NODE_OPTIONS
-          value: "--max-old-space-size=200"
+          value: "--max-old-space-size=200 --permission --allow-fs-read=/usr/share/tb-js-executor/*"
         envFrom:
           - configMapRef:
               name: tb-kafka-config

--- a/openshift/thingsboard.yml
+++ b/openshift/thingsboard.yml
@@ -47,7 +47,7 @@ spec:
         - name: SCRIPT_BODY_TRACE_FREQUENCY
           value: "1000"
         - name: NODE_OPTIONS
-          value: "--max-old-space-size=200"
+          value: "--max-old-space-size=200 --permission --allow-fs-read=/usr/share/tb-js-executor/*"
         envFrom:
           - configMapRef:
               name: tb-kafka-config


### PR DESCRIPTION
Add --permission and --allow-fs-read=/usr/share/tb-js-executor/* to NODE_OPTIONS for all JS executor deployments to restrict filesystem access and sandbox script execution.